### PR TITLE
Rmv invoking parens to fit jQuery callback signtr.

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -128,4 +128,4 @@ $(function() {
     menuIcon.on('click', function() {
         $('body').toggleClass('menu-hidden');
     });
-}());
+});


### PR DESCRIPTION
I removed parentheses on 131, which were immediately invoking
the anonymous function, which was contradicting the stated
intention to use `$` to invoke the code only after the `ready` event.