### PR TITLE
Rmv invoking parens on callback

### DIFF
--- a/jasmine/spec/feedreader.js
+++ b/jasmine/spec/feedreader.js
@@ -69,4 +69,4 @@ $(function() {
          * by the loadFeed function that the content actually changes.
          * Remember, loadFeed() is asynchronous.
          */
-}());
+});

--- a/js/app.js
+++ b/js/app.js
@@ -128,4 +128,4 @@ $(function() {
     menuIcon.on('click', function() {
         $('body').toggleClass('menu-hidden');
     });
-}());
+};


### PR DESCRIPTION
In two places you wrap an anonymous function in `$()`, for the stated
purpose of ensuring that the code in the function waits until browser
ready before executing, however you invoke the anonymous function with
parentheses.

This means that the code in the function will immediately execute, and
the return value of the function will be given to `$()`. Since the
return value is not a function, this contradicts the correct usage of
the jQuery method, and contradicts the stated purpose of using $().

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/udacity/frontend-nanodegree-feedreader/10)
<!-- Reviewable:end -->
