### PR TITLE
Use current feed URL for Udacity Blog

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -10,7 +10,7 @@
 var allFeeds = [
     {
         name: 'Udacity Blog',
-        url: 'http://blog.udacity.com/feeds/posts/default?alt=rss'
+        url: 'http://blog.udacity.com/feed'
     }, {
         name: 'CSS Tricks',
         url: 'http://css-tricks.com/feed'


### PR DESCRIPTION
The feed URL for the udacity blog used in the project only gives articles up to late 2014. This fix uses the current feed URL.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/udacity/frontend-nanodegree-feedreader/12)
<!-- Reviewable:end -->
