### PR TITLE
delete redundant parentheses

### DIFF
--- a/jasmine/spec/feedreader.js
+++ b/jasmine/spec/feedreader.js
@@ -69,4 +69,4 @@ $(function() {
          * by the loadFeed function that the content actually changes.
          * Remember, loadFeed() is asynchronous.
          */
-}());
+});

--- a/js/app.js
+++ b/js/app.js
@@ -131,4 +131,4 @@ $(function() {
     menuIcon.on('click', function() {
         $('body').toggleClass('menu-hidden');
     });
-}());
+});


### PR DESCRIPTION
We actually want to pass a function to jQuery's $ `.ready` (https://api.jquery.com/ready/) function. But these redundant parentheses make the function expression become a IIFE(Immediately-invoked function expression) which return nothing(`undefined`).


