### PR TITLE
Added https to external libraries and fonts

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
         <title>UdaciFeeds</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Roboto:400,100,300,700">
+        <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,100,300,700">
         <link rel="stylesheet" href="css/normalize.css">
         <link rel="stylesheet" href="css/icomoon.css">
         <link rel="stylesheet" href="css/style.css">
@@ -47,9 +47,9 @@
             </li>
         </script>
 
-        <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
-        <script src="http://cdn.jsdelivr.net/handlebarsjs/2.0.0/handlebars.min.js"></script>
-        <script src="http://google.com/jsapi"></script>
+        <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/handlebarsjs/2.0.0/handlebars.min.js"></script>
+        <script src="https://google.com/jsapi"></script>
         <script src="js/app.js"></script>
 
         <script src="jasmine/spec/feedreader.js"></script>


### PR DESCRIPTION
The external fonts and libraries (jquery, handlebar and Google jsapi) are requested via http instead of https.
This leads to errors if https is enforced. (See Issue #23 )
