### PR TITLE
FIX: google's feeds module does not exist anymore

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -86,7 +86,6 @@ function init() {
 /* Google API: Loads the Feed Reader API and defines what function
  * to call when the Feed Reader API is done loading.
  */
-google.load('feeds', '1');
 google.setOnLoadCallback(init);
 
 /* All of this functionality is heavily reliant upon the DOM, so we


### PR DESCRIPTION
Google's `feeds` module doesn't exist anymore:
<img width="374" alt="appjs-error" src="https://cloud.githubusercontent.com/assets/1479192/24876154/e569ebb6-1e2a-11e7-827c-f32039bd1862.png">

But we don't need it since `app.js` relies on `https://rsstojson.udacity.com/parseFeed`.