### PR TITLE
Remove dependency on unused Google API loader

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,6 @@
 
         <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
         <script src="http://cdn.jsdelivr.net/handlebarsjs/2.0.0/handlebars.min.js"></script>
-        <script src="http://google.com/jsapi"></script>
         <script src="js/app.js"></script>
 
         <script src="jasmine/spec/feedreader.js"></script>

--- a/js/app.js
+++ b/js/app.js
@@ -114,5 +114,6 @@ $(function() {
         $('body').toggleClass('menu-hidden');
     });
 
+    // Load the first feed
     loadFeed(0);
 }());

--- a/js/app.js
+++ b/js/app.js
@@ -23,15 +23,6 @@ var allFeeds = [
     }
 ];
 
-/* This function starts up our application. The Google Feed
- * Reader API is loaded asynchonously and will then call this
- * function when the API is loaded.
- */
-function init() {
-    // Load the first feed we've defined (index of 0).
-    loadFeed(0);
-}
-
 /* This function performs everything necessary to load a
  * feed using the Google Feed Reader API. It will then
  * perform all of the DOM operations required to display
@@ -83,14 +74,9 @@ function init() {
      });
  }
 
-/* Google API: Loads the Feed Reader API and defines what function
- * to call when the Feed Reader API is done loading.
- */
-google.setOnLoadCallback(init);
-
-/* All of this functionality is heavily reliant upon the DOM, so we
- * place our code in the $() function to ensure it doesn't execute
- * until the DOM is ready.
+/* Start up the application. All of this functionality is heavily reliant upon
+ * the DOM, so we place our code in the $() function to ensure it doesn't
+ * execute until the DOM is ready.
  */
 $(function() {
     var container = $('.feed'),
@@ -130,4 +116,6 @@ $(function() {
     menuIcon.on('click', function() {
         $('body').toggleClass('menu-hidden');
     });
+
+    loadFeed(0);
 }());

--- a/js/app.js
+++ b/js/app.js
@@ -1,9 +1,8 @@
 /* app.js
  *
- * This is our RSS feed reader application. It uses the Google
- * Feed Reader API to grab RSS feeds as JSON object we can make
- * use of. It also uses the Handlebars templating library and
- * jQuery.
+ * This is our RSS feed reader application. It uses a Udacity API to grab RSS
+ * feeds as JSON objects we can make use of. It also uses the Handlebars
+ * templating library and jQuery.
  */
 
 // The names and URLs to all of the feeds we'd like available.
@@ -23,13 +22,11 @@ var allFeeds = [
     }
 ];
 
-/* This function performs everything necessary to load a
- * feed using the Google Feed Reader API. It will then
- * perform all of the DOM operations required to display
- * feed entries on the page. Feeds are referenced by their
- * index position within the allFeeds array.
- * This function all supports a callback as the second parameter
- * which will be called after everything has run successfully.
+/* This function performs everything necessary to load a feed using a Udacity
+ * API. It will then perform all of the DOM operations required to display feed
+ * entries on the page. Feeds are referenced by their index position within the
+ * allFeeds array. This function all supports a callback as the second
+ * parameter which will be called after everything has run successfully.
  */
  function loadFeed(id, cb) {
      var feedUrl = allFeeds[id].url,
@@ -51,10 +48,10 @@ var allFeeds = [
                  title.html(feedName);   // Set the header text
                  container.empty();      // Empty out all previous entries
 
-                 /* Loop through the entries we just loaded via the Google
-                  * Feed Reader API. We'll then parse that entry against the
-                  * entryTemplate (created above using Handlebars) and append
-                  * the resulting HTML to the list of entries on the page.
+                 /* Loop through the entries we just loaded via the Udacity
+                  * API. We'll then parse that entry against the entryTemplate
+                  * (created above using Handlebars) and append the resulting
+                  * HTML to the list of entries on the page.
                   */
                  entries.forEach(function(entry) {
                      container.append(entryTemplate(entry));


### PR DESCRIPTION
Although the project no longer used the deprecated Google Feed API, it still loaded the Google API loader and waited for it to load before calling init(). This change removes the dependency on the API loader entirely.